### PR TITLE
Less restrictive dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-click==3.3
-jdcal==1.0.1
-openpyxl==2.2.0b1
-polib==1.0.6
-six==1.9.0
+click>=3.3
+jdcal>=1.0.1
+openpyxl>=2.2.0b1
+polib>=1.0.6
+six>=1.9.0


### PR DESCRIPTION
Be less picky about dependency versions. This is currently causing problems for me with the recently release ``setuptools`` ``34.0.x`` version which requires ``six>=1.10.0``.